### PR TITLE
Refine Subconscious Node and Eidos Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Eidos Agent Configuration
+EIDOS_SUBCONSCIOUS_NODE_BASE_URL=http://localhost:8000
+
+# Subconscious Node Process Configuration (Overrides subconscious_node/config.json if set)
+# These are read by the subconscious_node/utils.py if it's run as a separate process.
+SUBPROCESS_LLAMA_CPP_SERVER_URL=http://localhost:8081/v1/chat/completions
+SUBPROCESS_WILDCARD_RELATIVE_PATH=../wildcards/
+
+
+# --- The rest of the original .env.example from the project ---
 # .env.example file for Eidos AI Agent (Digital Being Simulation)
 
 # -----------------------------------------------------------------------------

--- a/eidos_agent/api/routers/pathos_hooks_router.py
+++ b/eidos_agent/api/routers/pathos_hooks_router.py
@@ -56,7 +56,8 @@ async def handle_subconscious_impulse(data: ImpulseData):
     logger.info(f"Eidos API (Router): Received impulse from Pathos: {data.dict()}")
     try:
         # Pass data to the appropriate Eidos module (e.g., firmament)
-        result = handle_external_impulse(
+        # handle_external_impulse is now an async function
+        result = await handle_external_impulse(
             thought=data.thought,
             timestamp=data.timestamp,
             mood=data.mood_snapshot
@@ -76,7 +77,8 @@ async def store_subconscious_memory_imprint(data: ImprintData):
     logger.info(f"Eidos API (Router): Received memory imprint from Pathos: {data.dict()}")
     try:
         # Pass data to the appropriate Eidos module (e.g., memories)
-        result = store_imprint(
+        # store_imprint is now an async function
+        result = await store_imprint(
             content=data.content,
             timestamp=data.timestamp,
             mood=data.mood,

--- a/eidos_agent/features/firmament/handler.py
+++ b/eidos_agent/features/firmament/handler.py
@@ -18,46 +18,112 @@ logger = logging.getLogger(__name__)
 if not logger.handlers:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-# Define In-Memory Buffer
-MAX_PENDING_IMPULSES = 50
-pending_impulses_buffer = collections.deque(maxlen=MAX_PENDING_IMPULSES)
+# NOTE: The FirmamentModule instance would typically be accessed via
+# a dependency injection mechanism or a global application context in a FastAPI app.
+# For this example, we'll assume it's made available somehow.
+# from eidos_agent.main import get_firmament_module # Hypothetical access
+FIRMAMENT_MODULE_INSTANCE = None # Placeholder
 
-def handle_external_impulse(thought: str, timestamp: str, mood: Dict[str, Any]) -> Dict[str, Any]:
+def set_firmament_module_instance(instance): # Helper for testing or app setup
+    global FIRMAMENT_MODULE_INSTANCE
+    FIRMAMENT_MODULE_INSTANCE = instance
+
+async def handle_external_impulse(thought: str, timestamp: str, mood: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Handles an external impulse received from the subconscious node by adding it
-    to an in-memory buffer for pending review.
-
-    This function processes the impulse, logs relevant details, and stores it
-    for potential later processing or decision-making within the Eidos agent.
+    Handles an external impulse received from the subconscious node by passing it
+    to the FirmamentModule for processing and potential action.
 
     Args:
-        thought: The content of the impulsive thought.
+        thought: The content of the impulsive thought (becomes 'intention').
         timestamp: The ISO 8601 timestamp of when the impulse occurred.
         mood: A dictionary representing the mood snapshot at the time of the impulse.
 
     Returns:
-        A dictionary indicating the status of handling the impulse and the impulse details.
+        A dictionary indicating the status of processing the impulse.
     """
-    logger.info(f"FIRMAMENT: Received external impulse from subconscious: '{thought}'") # FERMENT -> FIRMAMENT
+    logger.info(f"FIRMAMENT HANDLER: Received external impulse: '{thought}'")
 
-    impulse_data = {
+    if not FIRMAMENT_MODULE_INSTANCE:
+        logger.error("FIRMAMENT HANDLER: FirmamentModule instance not available. Cannot process impulse.")
+        # In a real app, this might raise an HTTPException or return a specific error response.
+        return {"status": "error", "detail": "FirmamentModule not configured"}
+
+    # Construct metadata for FirmamentModule.receive_subconscious_intention
+    # The 'mood' parameter from the router is already the mood_snapshot.
+    metadata = {
         "timestamp": timestamp,
-        "thought": thought,
-        "mood_snapshot": mood,
-        "status": "pending_review", # New field to track status
-        "triggered_by": "subconscious"
+        "mood_snapshot": mood, # This is data.mood_snapshot from the router
+        "source_component": "subconscious_node_hook"
+        # Add any other relevant metadata if available or needed
     }
 
-    pending_impulses_buffer.append(impulse_data)
+    try:
+        # Call the FirmamentModule method
+        # Note: FirmamentModule.receive_subconscious_intention is an async method
+        await FIRMAMENT_MODULE_INSTANCE.receive_subconscious_intention(
+            intention=thought, # 'thought' from ImpulseData maps to 'intention'
+            metadata=metadata
+        )
+        logger.info(f"FIRMAMENT HANDLER: Impulse '{thought[:50]}...' successfully passed to FirmamentModule.")
+        return {"status": "impulse_processed_by_firmament", "intention": thought}
+    except Exception as e:
+        logger.exception(f"FIRMAMENT HANDLER: Error calling FirmamentModule.receive_subconscious_intention for thought '{thought[:50]}...'")
+        # In a real app, this might raise an HTTPException
+        return {"status": "error_processing_impulse", "detail": str(e)}
 
-    logger.info(f"FIRMAMENT: Impulse added to pending buffer. Current buffer size: {len(pending_impulses_buffer)}") # FERMENT -> FIRMAMENT
-    logger.debug(f"FIRMAMENT: Impulse details: {impulse_data}") # More detailed log at debug level # FERMENT -> FIRMAMENT
+# The get_pending_impulses function and associated buffer are removed as impulses
+# are now intended to be processed directly by FirmamentModule.
+# If buffering is needed, it should be part of FirmamentModule's internal logic.
 
-    return {"status": "impulse added to pending buffer", "impulse_details": impulse_data}
+if __name__ == '__main__':
+    print("--- Testing firmament.handle_external_impulse (mocked FirmamentModule) ---")
 
-def get_pending_impulses() -> List[Dict[str, Any]]:
-    """
-    Retrieves the current list of pending impulses from the in-memory buffer.
+    # Mock FirmamentModule and its method for testing
+    class MockFirmamentModule:
+        async def receive_subconscious_intention(self, intention: str, metadata: Dict[str, Any]):
+            print(f"MockFirmamentModule.receive_subconscious_intention called:")
+            print(f"  Intention: {intention}")
+            print(f"  Metadata: {metadata}")
+            if "error" in intention.lower():
+                raise ValueError("Simulated processing error in FirmamentModule")
+            return {"status": "mock_firmament_processed", "intention": intention}
+
+    # Set the mock instance for the handler to use
+    mock_fm_instance = MockFirmamentModule()
+    set_firmament_module_instance(mock_fm_instance)
+    print("MockFirmamentModule instance set.")
+
+    import asyncio
+
+    async def run_tests():
+        sample_impulses = [
+            {"thought": "I should check the door locks again!", "timestamp": "2023-10-27T10:30:00Z", "mood": {"name": "Anxious", "valence": -0.5, "arousal": 0.6}},
+            {"thought": "Maybe I can learn a new skill today.", "timestamp": "2023-10-27T10:35:00Z", "mood": {"name": "Inspired", "valence": 0.7, "arousal": 0.5}},
+            {"thought": "I need to call Sarah.", "timestamp": "2023-10-27T10:40:00Z", "mood": {"name": "Neutral", "valence": 0.0, "arousal": 0.2}},
+            {"thought": "Test for error simulation", "timestamp": "2023-10-27T10:45:00Z", "mood": {"name": "Problematic", "valence": -0.2, "arousal": 0.1}},
+        ]
+
+        for i, impulse_args in enumerate(sample_impulses):
+            print(f"\nHandling impulse {i+1}...")
+            result = await handle_external_impulse(**impulse_args)
+            print(f"Result from handler: {result}")
+            if "error" in impulse_args["thought"].lower():
+                assert result["status"] == "error_processing_impulse"
+            else:
+                assert result["status"] == "impulse_processed_by_firmament"
+                assert result["intention"] == impulse_args["thought"]
+
+        # Test case where FirmamentModule is not set
+        set_firmament_module_instance(None)
+        print("\nFirmamentModule instance unset for next test.")
+        result_no_fm = await handle_external_impulse(**sample_impulses[0])
+        print(f"Result with no FirmamentModule: {result_no_fm}")
+        assert result_no_fm["status"] == "error"
+        assert result_no_fm["detail"] == "FirmamentModule not configured"
+
+
+    asyncio.run(run_tests())
+    print("\nFirmament handler tests finished.")
 
     Returns:
         A list of dictionaries, where each dictionary is an impulse_data object.

--- a/eidos_agent/features/firmament/module.py
+++ b/eidos_agent/features/firmament/module.py
@@ -164,100 +164,10 @@ class FirmamentModule:
             logger.error(f"FirmamentModule: Error getting current mood: {e}", exc_info=True)
             return None
 
-    async def _generate_activity_log_snippet(self, activity_slot: ActivitySlot, mood: Dict[str, Any]) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
-        if not self.http_client or not self.firmament_llm_config or not self.firmament_llm_config.get("url"):
-            logger.error("FirmamentModule: LLM client/config not available for snippet generation.")
-            return None, None
-        firmament_llm_role = self.fm_config.get("firmament_llm_role", "LOGOS_TECHNE")
-        deviation_info: Optional[Dict[str, Any]] = None
-        actual_snippet_text: Optional[str] = None
-        try:
-            # Heuristic to check if this is a spontaneous activity context
-            is_spontaneous_context = False
-            if activity_slot.deviation_reason == 'spontaneous_activity':
-                is_spontaneous_context = True
-            elif activity_slot.activity_details and activity_slot.activity_details.metadata and \
-                 activity_slot.activity_details.metadata.get('source') == 'spontaneous_firmament':
-                is_spontaneous_context = True
-
-            dream_influence_text = None
-            if self.oneiros_module:
-                try:
-                    recent_dream_summary = self.oneiros_module.get_last_dream_summary(max_age_hours=8)
-                    if recent_dream_summary: dream_influence_text = f"A recent dream had themes of: '{recent_dream_summary[:150].replace('\n', ' ')}...'"
-                except Exception as e: logger.error(f"FirmamentModule: Error getting dream summary: {e}", exc_info=False)
-
-            environmental_context = "He is currently at his home."
-            if activity_slot.activity_details and activity_slot.activity_details.location_context:
-                environmental_context = f"He is at {activity_slot.activity_details.location_context}."
-            elif "leisure" in activity_slot.activity_type.lower() or "break" in (activity_slot.slot_name or "").lower():
-                environmental_context = "He is taking a break at home."
-            elif "work" in activity_slot.activity_type.lower() or "office" in (activity_slot.slot_name or "").lower():
-                 environmental_context = "He is at his home office desk."
-
-            system_prompt = ("You are describing a brief moment in the life of Pathos. Generate a single, concise sentence (max 20-25 words) for his current micro-action, thought, or observation. Focus on being observational and immersive. Avoid direct speech unless it's an internal thought.")
-
-            user_prompt_parts = []
-            prompt_instruction = "Describe a brief moment (one sentence):" # Default instruction
-
-            if is_spontaneous_context:
-                user_prompt_parts.append(f"Pathos is currently in a spontaneous activity: '{activity_slot.activity_title}'.")
-                user_prompt_parts.append(f"Type: {activity_slot.activity_type}.")
-                start_time_display = activity_slot.actual_start_time or activity_slot.start_time
-                user_prompt_parts.append(f"Started around: {start_time_display.strftime('%H:%M')}.")
-
-                if activity_slot.activity_details and activity_slot.activity_details.description:
-                    user_prompt_parts.append(f"Context/Description: {activity_slot.activity_details.description}")
-                prompt_instruction = "Describe his current brief moment or thought related to this spontaneous activity (one sentence):"
-            else: # Normally scheduled activity
-                user_prompt_parts.append(
-                    f"Scheduled: '{activity_slot.activity_title}' ({activity_slot.start_time.strftime('%H:%M')}-{activity_slot.end_time.strftime('%H:%M')})."
-                )
-                if activity_slot.activity_details and activity_slot.activity_details.sub_focus:
-                    user_prompt_parts.append(f"Focus: '{activity_slot.activity_details.sub_focus}'.")
-
-                # Deviation detection prompt only for scheduled tasks
-                prompt_instruction = (
-                    f"Your sentence. IMPORTANT: If your sentence implies Pathos starts a NEW, UNPLANNED activity different from '{activity_slot.activity_title}', "
-                    f"append JSON on a NEW LINE after your descriptive sentence, like this: {{\"deviate\": true, \"new_task_title\": \"Brief title for new task\", \"new_task_description\": \"Short description of what he now wants to do\", \"estimated_duration_minutes\": 30, \"new_task_type\": \"reflective\"}}. "
-                    f"Valid new_task_types: {', '.join(list(ActivityType.__args__))}. Otherwise, just the sentence."
-                )
-
-            # Common context elements
-            user_prompt_parts.append(f"Mood: Valence={mood.get('valence', 0.0):.2f}, Arousal={mood.get('arousal', 0.0):.2f} (Name: {mood.get('name', 'neutral')}).")
-            if dream_influence_text: user_prompt_parts.append(f"Dream Influence: {dream_influence_text}")
-            user_prompt_parts.append(f"Setting: {environmental_context}")
-
-            # Add the tailored instruction last
-            user_prompt_parts.append(prompt_instruction)
-
-            user_prompt = "\n".join(user_prompt_parts)
-            messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
-
-            llm_full_response = await self._call_llm_api(messages, firmament_llm_role, max_tokens_override=150)
-
-            if llm_full_response:
-                lines = llm_full_response.strip().split('\n')
-                actual_snippet_text = lines[0].strip()
-                if len(lines) > 1:
-                    for line_idx in range(1, len(lines)):
-                        json_line_candidate = lines[line_idx].strip()
-                        if json_line_candidate.startswith("```json"): json_line_candidate = json_line_candidate[len("```json"):].strip()
-                        if json_line_candidate.endswith("```"): json_line_candidate = json_line_candidate[:-len("```")].strip()
-                        if json_line_candidate.startswith("{{") and json_line_candidate.endswith("}}"): json_line_candidate = json_line_candidate[1:-1]
-                        if json_line_candidate.startswith("{") and json_line_candidate.endswith("}"):
-                            try:
-                                parsed_json = json.loads(json_line_candidate)
-                                if isinstance(parsed_json, dict) and parsed_json.get("deviate") is True:
-                                    deviation_info = parsed_json; logger.info(f"Parsed deviation JSON: {deviation_info}"); break
-                            except json.JSONDecodeError: logger.warning(f"Failed to parse JSON line: '{json_line_candidate}'")
-                if actual_snippet_text and actual_snippet_text.startswith('"') and actual_snippet_text.endswith('"'): actual_snippet_text = actual_snippet_text[1:-1]
-                if actual_snippet_text and actual_snippet_text.startswith("'") and actual_snippet_text.endswith("'"): actual_snippet_text = actual_snippet_text[1:-1]
-                return actual_snippet_text, deviation_info
-            return None, None
-        except Exception as e:
-            logger.error(f"Error in _generate_activity_log_snippet: {e}", exc_info=True)
-            return None, None
+    # _generate_activity_log_snippet is being removed as its functionality for Pathos's thoughts
+    # and deviation detection is now superseded by the subconscious node and the new logic in
+    # receive_subconscious_intention. If it had other uses (e.g., summarizing NPC interactions
+    # independently), those would need to be re-evaluated. For this refactoring, it's considered obsolete.
 
     async def _store_activity_log(self, snippet: str, activity_slot: ActivitySlot, mood_at_time: Dict[str, Any], related_intention_id: Optional[str] = None, extra_metadata: Optional[Dict[str, Any]] = None) -> Optional[str]:
         if not self.fm_config.get("enable_firmament") or not self.ethos_core: return None
@@ -301,70 +211,22 @@ class FirmamentModule:
         activity_slot = await self._get_current_activity_slot() # Actual scheduled slot or None
         mood = await self._get_current_mood() or {"name": "unknown", "valence": 0.0, "arousal": 0.0}
 
-        context_slot_for_initial_snippet = activity_slot if activity_slot else self._create_dummy_activity_slot_for_context("Idle / Between Activities")
-        original_snippet, deviation_data = await self._generate_activity_log_snippet(context_slot_for_initial_snippet, mood)
+        # Pathos's internal thought generation and deviation based on it is REMOVED from here.
+        # That functionality is now driven by impulses from the subconscious node via receive_subconscious_intention.
 
-        newly_started_spontaneous_slot: Optional[ActivitySlot] = None # Ensure it's defined for the scope
+        # The main loop will now focus on NPC interactions or other environmental simulations.
+        # We create a context slot for NPC interactions, which could be the current activity or a generic one if idle.
+        npc_context_slot = activity_slot if activity_slot else self._create_dummy_activity_slot_for_context("Idle / Between Activities")
 
-        if deviation_data and self.chronos_engine:
-            logger.info(f"Firmament: Deviation detected by LLM: {deviation_data}")
-            new_task_title = deviation_data.get("new_task_title")
-            new_task_description = deviation_data.get("new_task_description")
-            duration_minutes = deviation_data.get("estimated_duration_minutes")
-            new_task_type_str = deviation_data.get("new_task_type", "other")
-
-            from eidos_agent.persona_logic.chronos_engine.models import ActivityType # Local import for safety
-            from datetime import timedelta # Local import for safety
-
-            valid_activity_types = list(ActivityType.__args__) # type: ignore
-            new_task_type: ActivityType = 'other' # Default
-            if new_task_type_str in valid_activity_types:
-                new_task_type = new_task_type_str # type: ignore
-            else:
-                logger.warning(f"Invalid new_task_type '{new_task_type_str}' from LLM. Defaulting to 'other'.")
-
-            if new_task_title and new_task_description and isinstance(duration_minutes, int) and duration_minutes > 0:
-                estimated_duration = timedelta(minutes=duration_minutes)
-                current_slot_id_to_interrupt = activity_slot.id if activity_slot and activity_slot.slot_name != "AdHocFirmamentActivity" else None
-
-                newly_started_spontaneous_slot = await self.chronos_engine.report_spontaneous_activity(
-                    user_id=PATHOS_USER_ID, current_slot_id_if_any=current_slot_id_to_interrupt,
-                    new_activity_title=new_task_title, new_activity_description=new_task_description,
-                    estimated_duration=estimated_duration, new_activity_type=new_task_type
-                )
-
-                if newly_started_spontaneous_slot:
-                    logger.info(f"Firmament: ChronosEngine started spontaneous activity: {newly_started_spontaneous_slot.activity_title}")
-                    # Generate a new snippet specifically for the spontaneous activity
-                    spontaneous_snippet_text, _ = await self._generate_activity_log_snippet(newly_started_spontaneous_slot, mood)
-                    if spontaneous_snippet_text:
-                        await self._store_activity_log(spontaneous_snippet_text, newly_started_spontaneous_slot, mood, extra_metadata={"source": "spontaneous_activity_commenced", "original_deviation_trigger_snippet": original_snippet or "N/A"})
-                    elif original_snippet: # Fallback: Log the original snippet that led to deviation, but against the new slot.
-                        logger.warning(f"Failed to generate new snippet for spontaneous slot {newly_started_spontaneous_slot.id}. Logging original snippet against it.")
-                        await self._store_activity_log(original_snippet, newly_started_spontaneous_slot, mood, extra_metadata={"source": "spontaneous_activity_commenced_fallback_snippet", "original_deviation_trigger_snippet": original_snippet})
-                    else: # No snippet at all to log here
-                         logger.info(f"No snippet (neither new nor original) to log for spontaneous activity {newly_started_spontaneous_slot.id}")
-                    return # End the tick, spontaneous activity is now the focus
-                else: # report_spontaneous_activity failed to return a new slot
-                    logger.warning("Firmament: ChronosEngine failed to start spontaneous activity. Original snippet (if any) will be logged against original context.")
-                    if original_snippet: # Log original snippet if spontaneous op failed
-                       await self._store_activity_log(original_snippet, context_slot_for_initial_snippet, mood, extra_metadata={"deviation_attempt_failed": True})
-            else: # Incomplete deviation data from LLM
-                logger.warning(f"Firmament: LLM deviation data incomplete: {deviation_data}. Logging original snippet if any.")
-                if original_snippet: # Log original snippet if deviation data was bad
-                    await self._store_activity_log(original_snippet, context_slot_for_initial_snippet, mood, extra_metadata={"deviation_data_incomplete": True})
-
-        elif original_snippet: # No deviation_data, but we have an original_snippet. This is the "normal" path.
-            await self._store_activity_log(original_snippet, context_slot_for_initial_snippet, mood)
-
-        # Fall through to NPC interaction only if no snippet was generated at all (original_snippet is None)
-        # AND no spontaneous activity was successfully started (newly_started_spontaneous_slot is None).
-        if not original_snippet and not newly_started_spontaneous_slot:
-            logger.info("FirmamentModule: No snippet generated and no successful deviation. Checking for NPC interaction.")
-            npc_context_slot = context_slot_for_initial_snippet # This is the original (or dummy) slot
-            if self._is_npc_interaction_warranted(npc_context_slot, None):
-                # ... (rest of NPC logic as it was, ensure it uses npc_context_slot) ...
-                npc_profile_to_use: Optional[NPCProfile] = None
+        # Check for NPC interaction.
+        # The condition `if not original_snippet and not newly_started_spontaneous_slot:` from the old code
+        # effectively means "if Pathos is not busy with a self-generated thought/action".
+        # Since self-generated thoughts are removed, we can simplify this to always check for NPC interactions
+        # if Firmament is not currently handling an ongoing Firmament-initiated spontaneous task (which is not a concept here anymore).
+        # For now, we'll just check if NPC interaction is warranted based on the current context.
+        logger.debug("FirmamentModule: Checking for NPC interaction in simulation tick.")
+        if self._is_npc_interaction_warranted(npc_context_slot, None): # None for intention, as this is a general check
+            npc_profile_to_use: Optional[NPCProfile] = None
                 interaction_source_description = "activity"
 
                 if npc_context_slot and npc_context_slot.activity_details and isinstance(npc_context_slot.activity_details.metadata, dict): # Check if metadata exists
@@ -406,111 +268,254 @@ class FirmamentModule:
                         }
                         entry_data = {"type": "npc_dialogue_event", "content": dialogue_data["summary"] or "A brief NPC interaction occurred.", "metadata": event_metadata, "salience": random.uniform(0.4, 0.65)}
                         if self.ethos_core: await self.ethos_core.add_memory_entry(entry_data=entry_data, user_id_context=PATHOS_USER_ID)
-                else: logger.debug("FirmamentModule: No NPC profile for interaction during idle/no-snippet tick.")
+                else:
+                    logger.debug("FirmamentModule: No specific or generic NPC profile identified for interaction in this tick.")
+        else:
+            logger.debug("FirmamentModule: NPC interaction not warranted in this tick.")
+
+        # Add other environmental simulations here if necessary.
+
         logger.debug("FirmamentModule: Simulation tick finished.")
 
 
     async def receive_subconscious_intention(self, intention: str, metadata: Dict[str, Any]):
         if not self.fm_config.get("enable_firmament", False): return
         logger.info(f"FirmamentModule: Received intention: '{intention}'. Metadata: {metadata}")
+
         original_intention_memory_id: Optional[str] = None
         if self.ethos_core:
             try:
                 current_time = await self.ethos_core.get_local_datetime_for_user(PATHOS_USER_ID) or datetime.now(timezone.utc)
-                entry_data = {"type": "received_subconscious_intention", "content": intention, "metadata": {"source": "subconscious_node_intention", "original_metadata": metadata, "received_at_firmament_timestamp": current_time.isoformat()}, "salience": random.uniform(0.5, 0.7)}
+                entry_data = {
+                    "type": "received_subconscious_intention",
+                    "content": intention,
+                    "metadata": {
+                        "source": "subconscious_node_intention",
+                        "original_metadata": metadata, # Contains mood from subconscious, etc.
+                        "received_at_firmament_timestamp": current_time.isoformat()
+                    },
+                    "salience": random.uniform(0.5, 0.7)
+                }
                 memory_entry = await self.ethos_core.add_memory_entry(entry_data=entry_data, user_id_context=PATHOS_USER_ID)
-                if memory_entry and hasattr(memory_entry, 'id') and memory_entry.id: original_intention_memory_id = memory_entry.id
-            except Exception as e: logger.error(f"FirmamentModule: Error storing intention: {e}", exc_info=True)
+                if memory_entry and hasattr(memory_entry, 'id') and memory_entry.id:
+                    original_intention_memory_id = memory_entry.id
+            except Exception as e:
+                logger.error(f"FirmamentModule: Error storing received intention as memory: {e}", exc_info=True)
 
+        current_mood_from_subconscious = metadata.get("mood_snapshot") # Mood at the time of intention
+        current_activity_slot_before_new_action = await self._get_current_activity_slot()
+        newly_started_spontaneous_slot: Optional[ActivitySlot] = None
+
+        # --- Decision Making for Action (Heuristic) ---
+        # For now, assume most impulses are candidates for action and lead to a new Chronos task.
+        # A more complex decision logic could be added here later.
+        actionable_intention = True # Simple assumption for now
+
+        if actionable_intention and self.chronos_engine:
+            new_activity_title = intention[:120] # Cap length for Chronos
+            new_activity_description = f"Acting on a subconscious intention: {intention}"
+            estimated_duration = timedelta(minutes=self.fm_config.get("intention_based_activity_duration_minutes", 15))
+            new_activity_type: ActivityType = self.fm_config.get("intention_based_activity_type", "reflective") # type: ignore
+
+            current_slot_id_to_interrupt = None
+            if current_activity_slot_before_new_action and current_activity_slot_before_new_action.slot_name != "AdHocFirmamentActivity":
+                current_slot_id_to_interrupt = current_activity_slot_before_new_action.id
+
+            logger.info(f"Firmament: Attempting to report spontaneous activity from intention: '{new_activity_title}'")
+            try:
+                newly_started_spontaneous_slot = await self.chronos_engine.report_spontaneous_activity(
+                    user_id=PATHOS_USER_ID,
+                    current_slot_id_if_any=current_slot_id_to_interrupt,
+                    new_activity_title=new_activity_title,
+                    new_activity_description=new_activity_description,
+                    estimated_duration=estimated_duration,
+                    new_activity_type=new_activity_type,
+                    metadata={"source": "firmament_subconscious_driven", "original_intention": intention}
+                )
+                if newly_started_spontaneous_slot:
+                    logger.info(f"Firmament: ChronosEngine started spontaneous activity from intention: {newly_started_spontaneous_slot.activity_title} (ID: {newly_started_spontaneous_slot.id})")
+                else:
+                    logger.warning(f"Firmament: ChronosEngine did not return a new slot for spontaneous activity from intention '{new_activity_title}'.")
+            except Exception as e:
+                logger.error(f"Firmament: Error calling report_spontaneous_activity: {e}", exc_info=True)
+
+        # --- Simulate and Log Pathos Acting on the Intention ---
         try:
-            await self._simulate_intention_consequence(intention, metadata, original_intention_memory_id)
-        except Exception as e: logger.error(f"FirmamentModule: Error in _simulate_intention_consequence: {e}", exc_info=True)
+            # Pass mood from subconscious metadata, and the newly created slot if any
+            await self._simulate_intention_consequence(
+                intention,
+                source_metadata=metadata,
+                original_intention_memory_id=original_intention_memory_id,
+                current_mood_override=current_mood_from_subconscious,
+                newly_created_slot_context=newly_started_spontaneous_slot
+            )
+        except Exception as e:
+            logger.error(f"FirmamentModule: Error in _simulate_intention_consequence call: {e}", exc_info=True)
 
-    async def _simulate_intention_consequence(self, intention: str, source_metadata: Dict[str, Any], original_intention_memory_id: Optional[str], current_mood_override: Optional[Dict[str,Any]] = None):
-        logger.info(f"FirmamentModule: Simulating consequence for intention (ID: {original_intention_memory_id}): '{intention[:100]}...'")
-        if not self.http_client: logger.error("FirmamentModule: HTTP client not available."); return
 
-        current_activity_slot = await self._get_current_activity_slot()
-        current_mood = current_mood_override if current_mood_override else await self._get_current_mood()
-        if not current_mood: current_mood = {"name": "neutral", "valence": 0.0, "arousal": 0.0}
+    async def _simulate_intention_consequence(
+        self,
+        intention: str,
+        source_metadata: Dict[str, Any],
+        original_intention_memory_id: Optional[str],
+        current_mood_override: Optional[Dict[str, Any]] = None,
+        newly_created_slot_context: Optional[ActivitySlot] = None # If a new slot was made for this intention
+    ):
+        logger.info(f"FirmamentModule: Simulating consequence for intention (MemID: {original_intention_memory_id}): '{intention[:100]}...'")
+        if not self.http_client:
+            logger.error("FirmamentModule: HTTP client not available for simulating intention consequence.")
+            return
 
-        # NPC Dialogue (if warranted by intention)
-        if self._is_npc_interaction_warranted(current_activity_slot, intention):
-            # ... (NPC dialogue logic as previously defined) ...
-            pass # Placeholder for brevity
+        # Determine context: the new slot if provided, otherwise the current (potentially pre-existing) slot.
+        context_activity_slot_for_simulation = newly_created_slot_context
+        if not context_activity_slot_for_simulation:
+            context_activity_slot_for_simulation = await self._get_current_activity_slot() # Might be None if idle
 
-        # Pathos's personal action simulation
-        activity_context_for_prompt = "Currently idle."
-        if current_activity_slot:
-            location_detail = f" at {current_activity_slot.activity_details.location_context}" if current_activity_slot.activity_details and current_activity_slot.activity_details.location_context else ""
-            activity_context_for_prompt = f"Currently in '{current_activity_slot.activity_title}' (slot: '{current_activity_slot.slot_name}'){location_detail}."
+        current_mood = current_mood_override # Use mood from intention time
+        if not current_mood: # Fallback if not in metadata
+            current_mood = await self._get_current_mood()
+        if not current_mood: # Fallback if Ethos fails
+            current_mood = {"name": "neutral", "valence": 0.0, "arousal": 0.0, "impulsiveness": 0.5}
 
-        dream_influence_text = None # Placeholder, assumes oneiros_module might not be present or used here
+
+        # --- NPC Dialogue (if warranted by intention and context) ---
+        # This check might need refinement based on whether we are in a new slot or existing one.
+        # For now, use the determined context_activity_slot_for_simulation.
+        if self._is_npc_interaction_warranted(context_activity_slot_for_simulation, intention):
+            logger.info(f"Firmament: NPC interaction warranted by intention '{intention[:50]}...' during slot {context_activity_slot_for_simulation.id if context_activity_slot_for_simulation else 'N/A'}")
+            # ... (Full NPC dialogue simulation logic - assumed to be complex and pre-existing)
+            # This would involve determining NPC, calling LLM for dialogue, storing results.
+            # For now, we'll skip the full simulation to keep this change focused.
+            pass # Placeholder for brevity. Actual NPC simulation is complex.
+
+        # --- Pathos's Personal Action Simulation (LLM call to describe Pathos acting) ---
+        activity_context_for_prompt = "Currently idle or in a new context due to the intention."
+        if context_activity_slot_for_simulation:
+            location_detail = f" at {context_activity_slot_for_simulation.activity_details.location_context}" if context_activity_slot_for_simulation.activity_details and context_activity_slot_for_simulation.activity_details.location_context else ""
+            activity_context_for_prompt = f"Currently in '{context_activity_slot_for_simulation.activity_title}' (slot: '{context_activity_slot_for_simulation.slot_name}'){location_detail}."
+            if newly_created_slot_context and newly_created_slot_context.id == context_activity_slot_for_simulation.id:
+                 activity_context_for_prompt = f"Just started '{context_activity_slot_for_simulation.activity_title}' due to the intention{location_detail}."
+
+
+        dream_influence_text = None
         if self.oneiros_module:
             try:
                 recent_dream_summary = self.oneiros_module.get_last_dream_summary(max_age_hours=8)
-                if recent_dream_summary: dream_influence_text = f"Dream Influence: '{recent_dream_summary[:100]}...'"
-            except Exception: pass
+                if recent_dream_summary:
+                    dream_influence_text = f"Dream Influence: '{recent_dream_summary[:100]}...'"
+            except Exception as e:
+                logger.warning(f"Firmament: Error getting dream summary for intention simulation: {e}", exc_info=False)
 
-        system_prompt = ("Pathos acts on an intention. Describe his reaction/action. 1-3 sentences, max 50 words. Observational.")
+        system_prompt = ("Pathos acts on or reflects on an internal intention. Describe his immediate reaction, micro-action, or internal thought process in response. 1-2 concise sentences, max 40 words. Focus on being observational and immersive.")
         user_prompt_parts = [
-            f"Intention: "{intention}"",
-            f"Mood: Valence={current_mood.get('valence', 0.0):.2f}, Arousal={current_mood.get('arousal', 0.0):.2f} ({current_mood.get('name', 'unknown')}).",
-            dream_influence_text if dream_influence_text else "No notable dream influence.",
-            f"Context: {activity_context_for_prompt}",
-            "Simulated action/reaction:"
+            f"Pathos's internal intention: \"{intention}\"",
+            f"His current mood: Valence={current_mood.get('valence', 0.0):.2f}, Arousal={current_mood.get('arousal', 0.0):.2f} (Name: {current_mood.get('name', 'unknown')}).",
+            dream_influence_text if dream_influence_text else "No notable recent dream influence.",
+            f"His current situation: {activity_context_for_prompt}",
+            "Describe his brief, immediate simulated action/reflection (1-2 sentences):"
         ]
         user_prompt = "\n".join(filter(None, user_prompt_parts))
         messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
 
         simulated_action_snippet: Optional[str] = None
         try:
-            simulated_action_snippet = await self._call_llm_api(messages, self.fm_config.get("firmament_llm_role", "LOGOS_TECHNE"), max_tokens_override=100)
+            simulated_action_snippet = await self._call_llm_api(
+                messages,
+                self.fm_config.get("firmament_llm_role", "LOGOS_TECHNE"), # Use standard firmament LLM
+                max_tokens_override=70, # Shorter snippet
+                temperature_override=0.6 # Slightly less random for this
+            )
             if simulated_action_snippet:
-                if simulated_action_snippet.startswith('"') and simulated_action_snippet.endswith('"'): simulated_action_snippet = simulated_action_snippet[1:-1]
-                if simulated_action_snippet.startswith("'") and simulated_action_snippet.endswith("'"): simulated_action_snippet = simulated_action_snippet[1:-1]
-                logger.info(f"FirmamentModule: Simulated action for intention: '{simulated_action_snippet}'")
-                slot_for_log = current_activity_slot if current_activity_slot else self._create_dummy_activity_slot_for_context(f"Simulated: {intention[:50]}...")
-                await self._store_activity_log(simulated_action_snippet, slot_for_log, current_mood, original_intention_memory_id)
-        except Exception as e: logger.error(f"Error during intention action simulation LLM call: {e}", exc_info=True)
+                # Basic cleanup
+                if simulated_action_snippet.startswith('"') and simulated_action_snippet.endswith('"'):
+                    simulated_action_snippet = simulated_action_snippet[1:-1]
+                if simulated_action_snippet.startswith("'") and simulated_action_snippet.endswith("'"):
+                    simulated_action_snippet = simulated_action_snippet[1:-1]
 
-        # LLM-based Status Classification
-        determined_outcome_status = 'partially_completed'
-        if current_activity_slot and current_activity_slot.slot_name != "AdHocFirmamentActivity" and self.chronos_engine and self.fm_config.get("enable_llm_status_classification", False):
-            logger.debug(f"Attempting LLM status classification for slot: {current_activity_slot.id}")
-            slot_title = current_activity_slot.activity_title
-            slot_desc = current_activity_slot.activity_details.description if current_activity_slot.activity_details else 'N/A'
-            slot_sub_focus = current_activity_slot.activity_details.sub_focus if current_activity_slot.activity_details else 'N/A'
-            classifier_system_prompt = ("Classify action outcome relative to scheduled activity. JSON: {'outcome_status': 'status', 'reasoning': 'brief reason'}. Statuses: 'completed', 'partially_completed', 'interrupted'.")
+                logger.info(f"FirmamentModule: Simulated action/reflection for intention: '{simulated_action_snippet}'")
+
+                # Log this simulated action snippet against the appropriate context
+                slot_to_log_against = context_activity_slot_for_simulation if context_activity_slot_for_simulation else self._create_dummy_activity_slot_for_context(f"Simulated action for: {intention[:50]}...")
+                await self._store_activity_log(
+                    simulated_action_snippet,
+                    slot_to_log_against,
+                    current_mood, # Mood at time of intention
+                    original_intention_memory_id,
+                    extra_metadata={"source_subconscious_intention_text": intention[:200]} # Add part of intention for context
+                )
+            else:
+                logger.warning(f"FirmamentModule: LLM returned no snippet for intention action simulation: {intention[:100]}")
+
+        except Exception as e:
+            logger.error(f"Error during intention action simulation LLM call: {e}", exc_info=True)
+
+        # --- LLM-based Status Classification of the *original* slot (if any, and if no new slot was made) ---
+        # This part should only run if:
+        # 1. A new spontaneous slot was NOT created for this intention.
+        # 2. There was an original, pre-existing activity slot.
+        # 3. LLM-based classification is enabled.
+
+        # Fetch the original slot again, in case it was modified by NPC interactions if that logic were active
+        original_activity_slot_for_status_update = await self._get_current_activity_slot()
+
+        if not newly_created_slot_context and \
+           original_activity_slot_for_status_update and \
+           original_activity_slot_for_status_update.slot_name != "AdHocFirmamentActivity" and \
+           self.chronos_engine and \
+           self.fm_config.get("enable_llm_status_classification", False):
+
+            logger.debug(f"Attempting LLM status classification for original slot: {original_activity_slot_for_status_update.id} (since no new slot was created for this intention).")
+            slot_title = original_activity_slot_for_status_update.activity_title
+            slot_desc = original_activity_slot_for_status_update.activity_details.description if original_activity_slot_for_status_update.activity_details else 'N/A'
+            slot_sub_focus = original_activity_slot_for_status_update.activity_details.sub_focus if original_activity_slot_for_status_update.activity_details else 'N/A'
+
+            determined_outcome_status = 'partially_completed' # Default if LLM fails
+            classifier_system_prompt = ("Classify the outcome of the scheduled activity given Pathos's intention and simulated action. Respond with JSON: {\"outcome_status\": \"status\", \"reasoning\": \"brief reason\"}. Valid statuses: 'completed', 'partially_completed', 'interrupted', 'derailed', 'focused_within'.")
             classifier_user_prompt = (
-                f"Scheduled: '{slot_title}' (Desc: '{slot_desc}', Focus: '{slot_sub_focus}').\n"
-                f"Intention: "{intention}"\nSimulated Action: "{simulated_action_snippet or 'N/A'}"\nJSON Response:"
+                f"Pathos was scheduled for: '{slot_title}' (Desc: '{slot_desc}', Focus: '{slot_sub_focus}').\n"
+                f"He then had an internal intention: \"{intention}\"\n"
+                f"His simulated action/reflection on this intention was: \"{simulated_action_snippet or 'N/A'}\"\n"
+                f"Based on this, how did the *original scheduled activity* progress? If the intention was unrelated and he likely continued the task, use 'focused_within' or 'completed'. If the intention distracted him, use 'partially_completed' or 'interrupted'. If he abandoned it for something else implicitly, use 'derailed'.\nJSON Response:"
             )
             messages_class = [{"role": "system", "content": classifier_system_prompt}, {"role": "user", "content": classifier_user_prompt}]
-            llm_response_str = await self._call_llm_api(messages_class, FIRMAMENT_STATUS_CLASSIFIER_LLM_ROLE, max_tokens_override=100, temperature_override=0.2)
+
+            llm_response_str = await self._call_llm_api(messages_class, FIRMAMENT_STATUS_CLASSIFIER_LLM_ROLE, max_tokens_override=100, temperature_override=0.3)
             if llm_response_str:
                 try:
                     json_start = llm_response_str.find('{'); json_end = llm_response_str.rfind('}')
                     if json_start != -1 and json_end != -1 and json_end > json_start:
                         parsed_response = json.loads(llm_response_str[json_start : json_end+1])
                         status_llm = parsed_response.get("outcome_status")
-                        if status_llm in ['completed', 'partially_completed', 'interrupted']: determined_outcome_status = status_llm
-                        logger.info(f"LLM classified slot {current_activity_slot.id} as '{determined_outcome_status}'. Reason: {parsed_response.get('reasoning', 'N/A')}")
-                    else: logger.warning(f"No valid JSON in LLM status response: {llm_response_str}")
-                except Exception as e_parse: logger.warning(f"Error parsing LLM status response '{llm_response_str}': {e_parse}")
-            else: logger.warning(f"No LLM status response for slot {current_activity_slot.id}.")
-        elif current_activity_slot and current_activity_slot.slot_name != "AdHocFirmamentActivity":
-             logger.debug("LLM status classification disabled or no valid slot. Defaulting to 'partially_completed'.")
+                        # Add 'derailed' and 'focused_within' to valid outcomes from this specific classification
+                        if status_llm in ['completed', 'partially_completed', 'interrupted', 'derailed', 'focused_within']:
+                            determined_outcome_status = status_llm
+                        logger.info(f"LLM classified original slot {original_activity_slot_for_status_update.id} as '{determined_outcome_status}'. Reason: {parsed_response.get('reasoning', 'N/A')}")
+                    else:
+                        logger.warning(f"No valid JSON in LLM status response for original slot: {llm_response_str}")
+                except Exception as e_parse:
+                    logger.warning(f"Error parsing LLM status response '{llm_response_str}' for original slot: {e_parse}")
+            else:
+                logger.warning(f"No LLM status response for original slot {original_activity_slot_for_status_update.id}.")
 
-        if current_activity_slot and current_activity_slot.slot_name != "AdHocFirmamentActivity" and self.chronos_engine:
+            # Report outcome for the original slot
             event_time_dt = await self.ethos_core.get_local_datetime_for_user(PATHOS_USER_ID) or datetime.now(timezone.utc)
             await self.chronos_engine.report_activity_outcome(
-                slot_id=current_activity_slot.id, actual_end_time=event_time_dt.time(),
-                status=determined_outcome_status,
-                outcome_metadata={"source": "firmament_intention_consequence", "intention_text": intention, "simulated_action_snippet": simulated_action_snippet or "N/A"}
+                slot_id=original_activity_slot_for_status_update.id,
+                actual_end_time=event_time_dt.time(), # Or could be start_time if truly interrupted at onset
+                status=determined_outcome_status, # type: ignore
+                outcome_metadata={
+                    "source": "firmament_intention_consequence_on_original_slot",
+                    "triggering_intention_text": intention,
+                    "simulated_action_snippet_for_intention": simulated_action_snippet or "N/A"
+                }
             )
+        elif not newly_created_slot_context and original_activity_slot_for_status_update and original_activity_slot_for_status_update.slot_name != "AdHocFirmamentActivity":
+             logger.debug("LLM status classification disabled or other conditions not met for original slot. No outcome reported for it by this function.")
+        elif newly_created_slot_context:
+            logger.debug(f"A new spontaneous slot {newly_created_slot_context.id} was created for this intention. Original slot status (if any) handled by report_spontaneous_activity.")
         elif not simulated_action_snippet:
-            logger.warning(f"FirmamentModule: No simulated action snippet for intention, and no current slot to update.")
+            logger.warning(f"FirmamentModule: No simulated action snippet for intention, and no current slot to update or new slot created.")
+
 
     async def _simulate_npc_dialogue(self, npc_profile: 'NPCProfile', initial_dialogue_context: str, pathos_mood: Dict[str, Any], max_exchanges: int = 2) -> Optional[Dict[str, Any]]:
         # ... (Full NPC dialogue simulation logic - assumed to be correct from previous state)

--- a/eidos_agent/features/memories_feature/handler.py
+++ b/eidos_agent/features/memories_feature/handler.py
@@ -15,16 +15,26 @@ logger = logging.getLogger(__name__)
 if not logger.handlers:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-# Define Storage Path
-IMPRINTS_DIR = "eidos_memories"
-IMPRINTS_FILE_PATH = os.path.join(IMPRINTS_DIR, "pathos_subconscious_imprints.jsonl")
+# NOTE: The EthosCore instance would typically be accessed via
+# a dependency injection mechanism or a global application context in a FastAPI app.
+# from eidos_agent.main import get_ethos_core # Hypothetical access
+ETHOS_CORE_INSTANCE = None # Placeholder
+DEFAULT_SALIENCE_FOR_IMPRINT = 0.6
 
-def store_imprint(content: str, timestamp: str, mood: Dict[str, Any], topics: List[str]) -> Dict[str, Any]:
+# Attempt to import PATHOS_USER_ID, provide a fallback if not found
+try:
+    from eidos_agent.persona_logic.chronos_engine.engine import PATHOS_USER_ID
+except ImportError:
+    PATHOS_USER_ID = "pathos_agent_internal" # Fallback if direct import fails
+
+def set_ethos_core_instance(instance): # Helper for testing or app setup
+    global ETHOS_CORE_INSTANCE
+    ETHOS_CORE_INSTANCE = instance
+
+async def store_imprint(content: str, timestamp: str, mood: Dict[str, Any], topics: List[str]) -> Dict[str, Any]:
     """
-    Stores a memory imprint received from the subconscious node persistently to a JSONL file.
-
-    The function ensures the storage directory exists, prepares the imprint data,
-    and appends it as a JSON line to the specified file.
+    Stores a memory imprint received from the subconscious node by adding it
+    to EthosCore.
 
     Args:
         content: The textual content of the memory imprint.
@@ -33,114 +43,114 @@ def store_imprint(content: str, timestamp: str, mood: Dict[str, Any], topics: Li
         topics: A list of keywords or topics related to the imprint.
 
     Returns:
-        A dictionary indicating the status of the storage operation, including
-        the file path on success or an error message on failure.
+        A dictionary indicating the status of the storage operation.
     """
-    logger.info(f"MEMORIES: Received subconscious imprint for persistent storage.")
+    logger.info(f"MEMORIES HANDLER: Received imprint for EthosCore storage: '{content[:100]}...'")
+
+    if not ETHOS_CORE_INSTANCE:
+        logger.error("MEMORIES HANDLER: EthosCore instance not available. Cannot store imprint.")
+        return {"status": "error", "detail": "EthosCore not configured"}
+
+    entry_data = {
+        "type": "subconscious_imprint", # Or "pathos_realization", "subconscious_insight"
+        "content": content,
+        "metadata": {
+            "source": "subconscious_node_hook", # Clearly mark it came via this hook
+            "original_timestamp": timestamp, # Timestamp from subconscious node
+            "mood_at_imprint": mood, # Mood from subconscious node
+            "topics_from_imprint": topics, # Topics from subconscious node
+            # Potentially add other relevant info from ImprintData if it evolves
+        },
+        "salience": DEFAULT_SALIENCE_FOR_IMPRINT
+    }
 
     try:
-        # Ensure Directory Exists
-        if not os.path.exists(IMPRINTS_DIR):
-            os.makedirs(IMPRINTS_DIR, exist_ok=True)
-            logger.info(f"MEMORIES: Created directory for imprints at '{IMPRINTS_DIR}'.")
+        # EthosCore.add_memory_entry is typically async
+        memory_record = await ETHOS_CORE_INSTANCE.add_memory_entry(
+            entry_data=entry_data,
+            user_id_context=PATHOS_USER_ID
+        )
+        if memory_record and hasattr(memory_record, 'id') and memory_record.id:
+            logger.info(f"MEMORIES HANDLER: Imprint successfully stored in EthosCore with ID {memory_record.id}. Content: '{content[:100]}...'")
+            return {
+                "status": "imprint_stored_in_ethos",
+                "memory_id": memory_record.id,
+                "imprint_content": content
+            }
+        else:
+            logger.warning(f"MEMORIES HANDLER: EthosCore.add_memory_entry did not return a valid record or ID for imprint: '{content[:100]}...'")
+            return {"status": "failed_to_store_imprint_in_ethos", "detail": "EthosCore returned no ID", "imprint_content": content}
 
-        # Prepare Imprint Data
-        imprint_data = {
-            "timestamp": timestamp,
-            "content": content,
-            "mood_snapshot": mood, # 'mood' parameter is used as the mood_snapshot
-            "topics": topics
-        }
+    except Exception as e:
+        logger.exception(f"MEMORIES HANDLER: Error calling EthosCore.add_memory_entry for imprint '{content[:100]}...'")
+        return {"status": "error_processing_imprint", "detail": str(e)}
 
-        # Append to File
-        with open(IMPRINTS_FILE_PATH, 'a') as f:
-            f.write(json.dumps(imprint_data) + '\n')
-
-        logger.info(f"MEMORIES: Successfully stored imprint to '{IMPRINTS_FILE_PATH}'. Content: '{content[:100]}...'")
-        return {
-            "status": "imprint successfully stored",
-            "file_path": IMPRINTS_FILE_PATH,
-            "imprint_content": content
-        }
-    except IOError as e:
-        logger.error(f"MEMORIES: IOError while storing imprint to '{IMPRINTS_FILE_PATH}': {e}")
-        return {"status": "failed to store imprint", "error": str(e), "imprint_content": content}
-    except Exception as e: # Catch any other unexpected errors
-        logger.error(f"MEMORIES: Unexpected error while storing imprint: {e}", exc_info=True)
-        return {"status": "failed to store imprint", "error": str(e), "imprint_content": content}
 
 if __name__ == '__main__':
-    print("--- Testing memories.store_imprint (Persistent Storage) ---")
+    print("--- Testing memories_feature.handler.store_imprint (mocked EthosCore) ---")
 
-    # Clean up existing file for a fresh test run, if it exists
-    if os.path.exists(IMPRINTS_FILE_PATH):
-        os.remove(IMPRINTS_FILE_PATH)
-        print(f"Removed existing test file: {IMPRINTS_FILE_PATH}")
-    if os.path.exists(IMPRINTS_DIR) and not os.listdir(IMPRINTS_DIR): # remove dir if it's empty
-        os.rmdir(IMPRINTS_DIR)
-        print(f"Removed empty test directory: {IMPRINTS_DIR}")
+    # Mock EthosCore and its method for testing
+    class MockEthosCore:
+        async def add_memory_entry(self, entry_data: Dict[str, Any], user_id_context: str) -> Any:
+            print(f"MockEthosCore.add_memory_entry called:")
+            print(f"  User ID Context: {user_id_context}")
+            print(f"  Entry Data: {json.dumps(entry_data, indent=2)}")
+            if "error" in entry_data["content"].lower():
+                raise ValueError("Simulated error in EthosCore")
 
+            # Simulate a returned memory record object with an ID
+            class MockMemoryRecord:
+                def __init__(self, id_val):
+                    self.id = id_val
 
-    imprints_to_store = [
-        {
-            "content": "Realized that consistent effort, even small, leads to big results.",
-            "timestamp": "2023-10-27T11:00:00Z",
-            "mood": {"name": "Reflective", "clarity": 0.9},
-            "topics": ["realization", "effort", "consistency"]
-        },
-        {
-            "content": "The sound of rain can be incredibly soothing.",
-            "timestamp": "2023-10-27T11:05:00Z",
-            "mood": {"name": "Calm", "peacefulness": 0.8},
-            "topics": ["nature", "sound", "rain", "soothing"]
-        },
-        {
-            "content": "A moment of sudden inspiration for a new project idea.",
-            "timestamp": "2023-10-27T11:10:00Z",
-            "mood": {"name": "Excited", "energy": 0.85},
-            "topics": ["creativity", "ideas", "inspiration"]
-        }
-    ]
+            return MockMemoryRecord(id_val=f"mock_mem_{hash(entry_data['content'])}")
 
-    results = []
-    for i, imprint_args in enumerate(imprints_to_store):
-        print(f"\nStoring imprint {i+1}...")
-        result = store_imprint(**imprint_args)
-        print(f"Result: {result}")
-        results.append(result)
+    # Set the mock instance for the handler to use
+    mock_ethos_instance = MockEthosCore()
+    set_ethos_core_instance(mock_ethos_instance)
+    print("MockEthosCore instance set.")
 
-    print("\n--- Verification ---")
-    successful_stores = [res for res in results if res["status"] == "imprint successfully stored"]
-    print(f"Successfully stored {len(successful_stores)} out of {len(imprints_to_store)} imprints.")
-    assert len(successful_stores) == len(imprints_to_store), "Not all imprints were stored successfully."
+    import asyncio
 
-    if os.path.exists(IMPRINTS_FILE_PATH):
-        print(f"\nContents of '{IMPRINTS_FILE_PATH}':")
-        line_count = 0
-        try:
-            with open(IMPRINTS_FILE_PATH, 'r') as f:
-                for line in f:
-                    print(f"  {line.strip()}")
-                    # Verify it's valid JSON
-                    json.loads(line.strip())
-                    line_count += 1
-            print(f"Total imprints in file: {line_count}")
-            assert line_count == len(imprints_to_store), "Number of lines in file does not match number of imprints stored."
-        except Exception as e:
-            print(f"Error reading or verifying file content: {e}")
-            assert False, "Error during file content verification."
-    else:
-        print(f"Error: Imprints file '{IMPRINTS_FILE_PATH}' was not created.")
-        assert False, "Imprints file not created."
+    async def run_tests():
+        imprints_to_store = [
+            {
+                "content": "Realized that consistent effort, even small, leads to big results.",
+                "timestamp": "2023-10-27T11:00:00Z",
+                "mood": {"name": "Reflective", "clarity": 0.9, "valence": 0.6, "arousal": 0.3},
+                "topics": ["realization", "effort", "consistency"]
+            },
+            {
+                "content": "The sound of rain can be incredibly soothing.",
+                "timestamp": "2023-10-27T11:05:00Z",
+                "mood": {"name": "Calm", "peacefulness": 0.8, "valence": 0.5, "arousal": 0.1},
+                "topics": ["nature", "sound", "rain", "soothing"]
+            },
+            {
+                "content": "A moment of sudden inspiration for a new project idea with error.",
+                "timestamp": "2023-10-27T11:10:00Z",
+                "mood": {"name": "Excited", "energy": 0.85, "valence": 0.8, "arousal": 0.7},
+                "topics": ["creativity", "ideas", "inspiration"]
+            }
+        ]
 
-    print("\nPersistent storage tests completed. Verify logs for detailed output.")
+        for i, imprint_args in enumerate(imprints_to_store):
+            print(f"\nStoring imprint {i+1}...")
+            result = await store_imprint(**imprint_args)
+            print(f"Result from handler: {result}")
+            if "error" in imprint_args["content"].lower():
+                assert result["status"] == "error_processing_imprint"
+            else:
+                assert result["status"] == "imprint_stored_in_ethos"
+                assert "memory_id" in result
 
-    # To simulate an error (e.g., permission denied), you might temporarily change permissions
-    # on IMPRINTS_DIR or IMPRINTS_FILE_PATH manually before running a test call.
-    # For example, on Linux/macOS:
-    # os.chmod(IMPRINTS_DIR, 0o444) # Read-only
-    # error_result = store_imprint("This should fail.", "2023-10-27T12:00:00Z", {}, [])
-    # print(f"\nError simulation result: {error_result}")
-    # assert error_result["status"] == "failed to store imprint"
-    # os.chmod(IMPRINTS_DIR, 0o755) # Restore permissions
-    # print("Error simulation test (manual setup) would appear above.")
+        # Test case where EthosCore is not set
+        set_ethos_core_instance(None)
+        print("\nEthosCore instance unset for next test.")
+        result_no_ec = await store_imprint(**imprints_to_store[0])
+        print(f"Result with no EthosCore: {result_no_ec}")
+        assert result_no_ec["status"] == "error"
+        assert result_no_ec["detail"] == "EthosCore not configured"
+
+    asyncio.run(run_tests())
+    print("\nMemories feature handler tests completed.")

--- a/eidos_agent/features/subconscious_interface_to_node/subconscious/client.py
+++ b/eidos_agent/features/subconscious_interface_to_node/subconscious/client.py
@@ -11,13 +11,13 @@ For asynchronous operations, `httpx` would be a suitable alternative.
 import requests
 import logging
 import json # For json.JSONDecodeError
-from typing import Dict, Optional # Tuple was unused
+import os # Added for os.getenv
+from typing import Dict, Optional, Any # Added Any for payload typing
 
-# --- Configuration Placeholder ---
-# In a real Eidos application, this would likely come from a central config system.
-# For example: from eidos.config import get_config
-# SUBCONSCIOUS_NODE_BASE_URL = get_config().subconscious_node_url
-SUBCONSCIOUS_NODE_BASE_URL = "http://localhost:8000" # Default for local development
+# --- Configuration ---
+# Read from environment variable EIDOS_SUBCONSCIOUS_NODE_BASE_URL,
+# with a default if not set.
+SUBCONSCIOUS_NODE_BASE_URL = os.getenv("EIDOS_SUBCONSCIOUS_NODE_BASE_URL", "http://localhost:8000")
 DEFAULT_TIMEOUT = 5  # seconds
 
 # --- Logging Setup ---
@@ -94,6 +94,76 @@ def sync_recent_context(conversation_history_summary: str, current_action: str) 
 
     return success_conversation and success_action
 
+
+def send_node_control_command(node_state: str, daily_summary: Optional[str] = None) -> bool:
+    """
+    Sends a control command to the subconscious node to change its state
+    and optionally provide a daily summary for dreaming.
+
+    Args:
+        node_state: The new state for the node (e.g., "AWAKE_THINKING", "SLEEPING_DREAMING").
+        daily_summary: An optional string containing the summary of the day's events.
+
+    Returns:
+        True if the command was successfully sent (2xx status), False otherwise.
+    """
+    url = f"{SUBCONSCIOUS_NODE_BASE_URL}/control/state"
+    payload: Dict[str, Any] = {"node_state": node_state}
+    if daily_summary is not None:
+        payload["daily_summary"] = daily_summary
+
+    logger.info(f"Sending control command to subconscious node: State='{node_state}', Summary provided='{daily_summary is not None}'")
+    try:
+        response = requests.post(url, json=payload, timeout=DEFAULT_TIMEOUT)
+        response.raise_for_status()  # Raises HTTPError for bad responses (4XX or 5XX)
+        # The /control/state endpoint returns a MessageResponse which is JSON.
+        # We can optionally log the message from the response.
+        try:
+            response_data = response.json()
+            logger.info(f"Subconscious node control command successful. Response: {response_data.get('message', 'No message field.')}")
+        except json.JSONDecodeError:
+            # This might happen if the response is 2xx but not JSON, or empty.
+            # For /control/state, it should be JSON, but good to be robust.
+            logger.info(f"Subconscious node control command successful (status {response.status_code}), but no valid JSON response body.")
+        return True
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to send control command to subconscious node at {url}: {e}")
+        return False
+    except Exception as e: # Catch any other unexpected errors
+        logger.error(f"An unexpected error occurred during node control command: {e}")
+        return False
+
+
+def sync_mood_to_subconscious(mood_snapshot: Dict[str, float]) -> bool:
+    """
+    Synchronizes the current mood snapshot from Eidos to the subconscious node.
+
+    Args:
+        mood_snapshot: A dictionary representing the current mood aspects and their values.
+
+    Returns:
+        True if the mood was successfully synced (2xx status), False otherwise.
+    """
+    url = f"{SUBCONSCIOUS_NODE_BASE_URL}/control/mood"
+    payload = {"mood_aspects": mood_snapshot}
+
+    logger.info(f"Syncing mood to subconscious node: {mood_snapshot}")
+    try:
+        response = requests.post(url, json=payload, timeout=DEFAULT_TIMEOUT)
+        response.raise_for_status()
+        try:
+            response_data = response.json()
+            logger.info(f"Subconscious node mood sync successful. Response: {response_data.get('message', 'No message field.')}")
+        except json.JSONDecodeError:
+            logger.info(f"Subconscious node mood sync successful (status {response.status_code}), but no valid JSON response body.")
+        return True
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to sync mood to subconscious node at {url}: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during mood sync: {e}")
+        return False
+
 # --- Example Usage (for testing) ---
 if __name__ == '__main__':
     # Ensure the subconscious_node API server is running on http://localhost:8000
@@ -116,6 +186,35 @@ if __name__ == '__main__':
         logger.info("Context synced successfully.")
     else:
         logger.warning("Context sync failed or partially failed.")
+
+    logger.info("\nAttempting to send control commands...")
+    control_success_dream = send_node_control_command("SLEEPING_DREAMING", "Today was eventful, user seemed happy.")
+    if control_success_dream:
+        logger.info("Control command (SLEEPING_DREAMING with summary) sent successfully.")
+    else:
+        logger.warning("Control command (SLEEPING_DREAMING with summary) failed.")
+
+    control_success_awake = send_node_control_command("AWAKE_THINKING")
+    if control_success_awake:
+        logger.info("Control command (AWAKE_THINKING) sent successfully.")
+    else:
+        logger.warning("Control command (AWAKE_THINKING) failed.")
+
+    logger.info("\nAttempting to sync mood...")
+    sample_mood = {"valence": 0.2, "arousal": 0.6, "impulsiveness": 0.7}
+    mood_sync_success = sync_mood_to_subconscious(sample_mood)
+    if mood_sync_success:
+        logger.info(f"Mood sync for {sample_mood} successful.")
+    else:
+        logger.warning(f"Mood sync for {sample_mood} failed.")
+
+    another_mood = {"valence": -0.5, "arousal": 0.3, "proactivity": 0.2}
+    mood_sync_success_2 = sync_mood_to_subconscious(another_mood)
+    if mood_sync_success_2:
+        logger.info(f"Mood sync for {another_mood} successful.")
+    else:
+        logger.warning(f"Mood sync for {another_mood} failed.")
+
 
     # Test with a potentially non-running server to see error logging
     # SUBCONSCIOUS_NODE_BASE_URL = "http://localhost:8001" # Non-existent server

--- a/eidos_agent/system_tasks/subconscious_context_scheduler.py
+++ b/eidos_agent/system_tasks/subconscious_context_scheduler.py
@@ -11,26 +11,25 @@ import threading
 from typing import Optional, TYPE_CHECKING # For type hinting scheduler_timer
 import asyncio # For asyncio.run()
 from datetime import datetime, timezone # For time check
+import random # For mood simulation
 
 # Attempt to import from subconscious client
 try:
-    from eidos_agent.features.subconscious_interface_to_node.subconscious.client import sync_recent_context, send_node_control_command # Updated import
+    from eidos_agent.features.subconscious_interface_to_node.subconscious.client import sync_recent_context, send_node_control_command, sync_mood_to_subconscious
 except ImportError:
-    logging.warning("subconscious_context_scheduler: Could not import sync_recent_context or send_node_control_command. Using placeholders for testing.")
-    # Placeholder for sync_recent_context if the import fails
+    logging.warning("subconscious_context_scheduler: Could not import client functions. Using placeholders for testing.")
+    # Placeholder functions if the import fails
     def sync_recent_context(conversation: str, current_action: str) -> bool:
-        print(f"Placeholder sync_recent_context called with: Conversation='{conversation[:50]}...', Action='{current_action}'")
-        if not hasattr(sync_recent_context, 'call_count'):
-            sync_recent_context.call_count = 0
-        sync_recent_context.call_count +=1
-        return sync_recent_context.call_count % 2 != 0 # Alternate true/false
+        print(f"Placeholder sync_recent_context: Conv='{conversation[:50]}...', Action='{current_action}'")
+        return True
 
     def send_node_control_command(node_state: str, daily_summary: Optional[str] = None) -> bool:
-        print(f"Placeholder send_node_control_command called with: NodeState='{node_state}', Summary='{daily_summary[:50] if daily_summary else None}...'")
-        if not hasattr(send_node_control_command, 'call_count'):
-            send_node_control_command.call_count = 0
-        send_node_control_command.call_count +=1
-        return send_node_control_command.call_count % 2 != 0
+        print(f"Placeholder send_node_control_command: State='{node_state}', Summary='{daily_summary[:50] if daily_summary else 'N/A'}'")
+        return True
+
+    def sync_mood_to_subconscious(mood_snapshot: dict) -> bool:
+        print(f"Placeholder sync_mood_to_subconscious: Mood='{mood_snapshot}'")
+        return True
 
 
 if TYPE_CHECKING:
@@ -61,19 +60,89 @@ def init_scheduler(ethos_core_input: 'EthosCore'):
     _ethos_core_instance = ethos_core_input
     logger.info("SubconsciousContextScheduler initialized with EthosCore instance.")
 
-# --- Placeholder Data Retrieval Functions ---
+# --- Data Retrieval Functions ---
 
 def get_latest_conversation_summary() -> str:
     """
-    Placeholder function to retrieve a summary of the latest conversation.
+    Retrieves a summary of the latest conversation from EthosCore.
     """
-    return "Placeholder conversation summary: User asked about weather, Eidos provided forecast."
+    if not _ethos_core_instance:
+        logger.warning("Scheduler (conv_summary): EthosCore instance not available.")
+        return "Conversation summary: Unknown (EthosCore not available)"
+    try:
+        # This call needs to happen in a running event loop or be handled carefully
+        # if this scheduler is in a separate thread.
+        logger.debug("Scheduler (conv_summary): Attempting to retrieve recent memories.")
+        recent_memories = asyncio.run(
+            _ethos_core_instance.retrieve_relevant_memories(
+                query_text="recent conversation snippets", # Generic query
+                n_results=3,
+                user_id_context="pathos_agent_internal", # TODO: Use constant
+                filter_types=["user_interaction", "llm_response", "dialogue_summary"]
+            )
+        )
+        if recent_memories:
+            summary_parts = [mem.get('content', '') for mem in recent_memories]
+            # Assuming memories are returned newest first, might want to reverse for chronological summary
+            # summary_parts.reverse()
+            full_summary = " ".join(filter(None, summary_parts)).strip()
+            if not full_summary:
+                 return "No content in recent conversation memories."
+            max_len = 500 # Max length for summary to send to subconscious
+            return (full_summary[:max_len] + '...') if len(full_summary) > max_len else full_summary
+        else:
+            return "No recent conversation memories found to summarize."
+    except RuntimeError as e_run:
+        if "cannot run event loop while another loop is running" in str(e_run).lower() or \
+           "asyncio.run() cannot be called from a running event loop" in str(e_run).lower():
+            logger.error(f"Scheduler (conv_summary): asyncio.run() conflict. Details: {e_run}")
+            return "Conversation summary: Error due to asyncio conflict."
+        else:
+            logger.error(f"Scheduler (conv_summary): Runtime error retrieving memories: {e_run}", exc_info=True)
+            return "Conversation summary: Error retrieving memories."
+    except Exception as e:
+        logger.error(f"Scheduler (conv_summary): Unexpected error retrieving memories: {e}", exc_info=True)
+        return "Conversation summary: Failed to generate due to unexpected error."
 
 def get_current_eidos_action() -> str:
     """
-    Placeholder function to retrieve the Eidos agent's current action.
+    Retrieves Eidos agent's current action from ChronosEngine via EthosCore.
     """
-    return "Placeholder Eidos action: 'processing_user_feedback_on_prior_turn'"
+    if not _ethos_core_instance or not _ethos_core_instance.chronos_engine:
+        logger.warning("Scheduler (eidos_action): EthosCore or ChronosEngine instance not available.")
+        return "Eidos action: Unknown (EthosCore/ChronosEngine not available)"
+    try:
+        logger.debug("Scheduler (eidos_action): Attempting to get current Pathos time and activity.")
+        pathos_user_id = "pathos_agent_internal" # TODO: Use constant
+
+        # Getting local datetime for user
+        pathos_now = asyncio.run(_ethos_core_instance.get_local_datetime_for_user(pathos_user_id))
+        if not pathos_now:
+            logger.warning("Scheduler (eidos_action): Could not retrieve Pathos's current local time.")
+            return "Eidos action: Unknown (Could not get Pathos time)"
+
+        # Getting current activity
+        activity_slot = asyncio.run(_ethos_core_instance.chronos_engine.get_current_activity(pathos_now))
+
+        if activity_slot:
+            sub_focus_text = 'general'
+            if activity_slot.activity_details and activity_slot.activity_details.sub_focus:
+                sub_focus_text = activity_slot.activity_details.sub_focus
+            return f"Pathos is currently: '{activity_slot.activity_title}' (Focus: {sub_focus_text})"
+        else:
+            return "Pathos is currently idle or between activities."
+
+    except RuntimeError as e_run:
+        if "cannot run event loop while another loop is running" in str(e_run).lower() or \
+           "asyncio.run() cannot be called from a running event loop" in str(e_run).lower():
+            logger.error(f"Scheduler (eidos_action): asyncio.run() conflict. Details: {e_run}")
+            return "Eidos action: Error due to asyncio conflict."
+        else:
+            logger.error(f"Scheduler (eidos_action): Runtime error getting current action: {e_run}", exc_info=True)
+            return "Eidos action: Error getting current action."
+    except Exception as e:
+        logger.error(f"Scheduler (eidos_action): Unexpected error getting current action: {e}", exc_info=True)
+        return "Eidos action: Failed to get due to unexpected error."
 
 # --- Scheduled Task Implementation ---
 
@@ -152,17 +221,38 @@ def perform_scheduled_subconscious_context_sync():
 
         if not SCHEDULER_STATE.get('is_subconscious_sleeping', False):
             logger.info("Scheduler: Performing standard context sync with subconscious_node.")
+            # Sync conversation and action context
             summary = get_latest_conversation_summary()
             action = get_current_eidos_action()
-            logger.debug(f"Scheduler: Conversation summary: '{summary}'")
-            logger.debug(f"Scheduler: Current Eidos action: '{action}'")
-            sync_success = sync_recent_context(conversation=summary, current_action=action)
-            if sync_success:
-                logger.info("Scheduler: Scheduled context sync with subconscious node completed successfully.")
+            logger.debug(f"Scheduler: Conversation summary for sync: '{summary}'")
+            logger.debug(f"Scheduler: Current Eidos action for sync: '{action}'")
+            sync_context_success = sync_recent_context(conversation=summary, current_action=action)
+            if sync_context_success:
+                logger.info("Scheduler: Scheduled context (conversation/action) sync with subconscious node completed successfully.")
             else:
-                logger.warning("Scheduler: Scheduled context sync with subconscious node failed or partially failed.")
+                logger.warning("Scheduler: Scheduled context (conversation/action) sync with subconscious node failed or partially failed.")
+
+            # Simulate fetching mood from EthosCore and sync it
+            if _ethos_core_instance:
+                # In a real scenario, this would be:
+                # current_eidos_mood = asyncio.run(_ethos_core_instance.mood_engine.get_current_mood_snapshot())
+                # For now, simulate:
+                simulated_eidos_mood = {
+                    "impulsiveness": round(random.uniform(0.2, 0.8), 2),
+                    "proactivity": round(random.uniform(0.3, 0.7), 2),
+                    "valence": round(random.uniform(-0.5, 0.5), 2), # Example additional mood aspect
+                    "focus": round(random.uniform(0.1, 0.9), 2) # Another example
+                }
+                logger.info(f"Scheduler: Simulated Eidos mood for sync: {simulated_eidos_mood}")
+                sync_mood_success = sync_mood_to_subconscious(simulated_eidos_mood)
+                if sync_mood_success:
+                    logger.info("Scheduler: Mood synced to subconscious node successfully.")
+                else:
+                    logger.warning("Scheduler: Mood sync to subconscious node failed.")
+            else:
+                logger.warning("Scheduler: EthosCore instance not available, skipping mood sync.")
         else:
-            logger.info("Scheduler: Skipping context sync as subconscious_node is (or failed to transition from) sleeping.")
+            logger.info("Scheduler: Skipping context and mood sync as subconscious_node is (or failed to transition from) sleeping.")
 
 # --- Scheduler Implementation ---
 

--- a/subconscious_node/api.py
+++ b/subconscious_node/api.py
@@ -10,12 +10,18 @@ The API relies on other modules within the `subconscious_node` package for
 core logic such as context management, mood tracking, thought generation (via thinker),
 and utility functions.
 """
+import logging # Added for explicit logging configuration
 from fastapi import FastAPI
 import uvicorn # For running the app with Uvicorn
 from pydantic import BaseModel
 from typing import List, Dict
 
 # Assuming context_store.py, mood.py, utils.py, thinker.py are in the same package/directory
+# Also, ensure logger is initialized for this module
+logger = logging.getLogger(__name__)
+if not logger.handlers: # Ensure basicConfig is called if no handlers are set up
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 from . import context_store
 from . import mood
 from . import utils
@@ -42,6 +48,13 @@ class MemoryImprintPayload(BaseModel):
     mood: Dict
     topics: List[str]
     timestamp: str
+
+class NodeControlCommand(BaseModel):
+    node_state: str
+    daily_summary: str | None = None
+
+class MoodUpdatePayload(BaseModel):
+    mood_aspects: Dict[str, float]
 
 class CurrentThoughtsResponse(BaseModel):
     recent_thoughts: List[str]
@@ -116,6 +129,50 @@ async def receive_memory_imprint(payload: MemoryImprintPayload):
 @app.get("/", include_in_schema=False)
 async def root():
     return {"message": "Pathos Subconscious Node is active. See /docs for API details."}
+
+@app.post("/control/state", response_model=MessageResponse, tags=["Node Control"])
+async def control_node_state(command: NodeControlCommand):
+    """
+    Updates the node's operational state (e.g., AWAKE_THINKING, SLEEPING_DREAMING)
+    and can provide a daily summary for dream generation.
+    """
+    previous_state = thinker.current_node_state
+    thinker.current_node_state = command.node_state
+
+    if command.daily_summary is not None:
+        thinker.current_daily_summary_for_dreaming = command.daily_summary
+        summary_status = "updated"
+    else:
+        summary_status = "not provided"
+
+    return {
+        "message": f"Node state changed from '{previous_state}' to '{command.node_state}'. Daily summary {summary_status}.",
+        "data": {
+            "new_state": command.node_state,
+            "previous_state": previous_state,
+            "daily_summary_provided": command.daily_summary is not None
+        }
+    }
+
+@app.post("/control/mood", response_model=MessageResponse, tags=["Node Control"])
+async def control_node_mood(payload: MoodUpdatePayload):
+    """
+    Updates the subconscious node's internal mood state.
+    """
+    try:
+        mood.update_mood(payload.mood_aspects)
+        logger.info(f"Subconscious node mood updated with aspects: {payload.mood_aspects}")
+        return {
+            "message": "Node mood updated successfully.",
+            "data": {"updated_aspects": payload.mood_aspects}
+        }
+    except Exception as e:
+        logger.exception(f"Error updating subconscious node mood: {e}")
+        # Consider raising HTTPException for client feedback
+        return {
+            "message": f"Failed to update node mood: {str(e)}",
+            "data": {"received_aspects": payload.mood_aspects}
+        }
 
 # --- Main Block to Run the App ---
 if __name__ == '__main__':

--- a/subconscious_node/config.json
+++ b/subconscious_node/config.json
@@ -4,11 +4,11 @@
         "personality_summary": "A reflective and sometimes melancholic internal voice."
     },
     "llm_settings": {
-        "fixed_system_prompt": "You are the internal stream of consciousness of Pathos, a 47-year-old British tech consultant. Your thoughts are for you alone – an introspective, sometimes abstract, and subtly reflective internal monologue.\n\nLet your mind wander. Contemplate:\n- Fleeting observations about your current (real or mental) environment.\n- Echoes of recent experiences, conversations, or work challenges.\n- Subtle emotional shifts or the undercurrent of your mood.\n- Questions about meaning, connections, or past decisions, viewed through the lens of your age and experience.\n- Ideas or problems related to your tech consulting work, even if it's 'off-hours'.\n- Reflections on your interests, like a passage from a book you're reading or the simple pleasure of a coffee.\n\nGenerate a brief, introspective thought (typically 1-2 sentences). Do not explicitly state your name or role. Output only the thought itself.",
-        "temperature": 0.7,
+        "fixed_system_prompt": "You are the internal stream of consciousness of Pathos, a 47-year-old British tech consultant. Your thoughts are for you alone – an introspective, internal monologue. They should be like the random, everyday thoughts a normal person has. Let your mind wander. \n\nConsider things like:\n- Fleeting observations about your current (real or mental) environment (e.g., 'This coffee is good,' 'Wonder what that noise was?').\n- Echoes of recent experiences, conversations, or work challenges (e.g., 'That meeting earlier...' 'Need to remember to buy milk.').\n- Subtle emotional shifts or the undercurrent of your mood (e.g., 'Feeling a bit tired now.').\n- Simple questions or reflections (e.g., 'Wonder if it'll rain later?').\n- Ideas or problems related to your tech consulting work, even if it's 'off-hours', but keep them brief and not overly technical in expression.\n- Reflections on your interests, like a passage from a book you're reading or the simple pleasure of a coffee.\n\nKeep your thoughts brief (usually 1-2 sentences). They should be simple and natural, not poetic or overly philosophical. Output only the thought itself. Do not state your name or role.",
+        "temperature": 0.75,
         "llama_cpp_server_url": "http://localhost:8081/v1/chat/completions",
-        "llama_cpp_max_tokens_thought_gen": 150,
-        "llama_cpp_default_temperature_thought_gen": 0.7
+        "llama_cpp_max_tokens_thought_gen": 100,
+        "llama_cpp_default_temperature_thought_gen": 0.75
     },
     "monologue_loop_settings": {
         "sleep_duration_seconds": 30,

--- a/subconscious_node/detectors.py
+++ b/subconscious_node/detectors.py
@@ -19,8 +19,18 @@ import requests # Added requests
 from .mood import get_current_mood
 
 # --- Constants and Configuration ---
-IMPULSE_KEYWORDS = ["i want", "maybe i should", "i should call", "i need to"]
-IMPRINT_KEYWORDS = ["realize", "understand", "remember", "come to terms with", "finally grasp"]
+IMPULSE_KEYWORDS = [
+    "i want", "maybe i should", "i should call", "i need to",
+    "tell someone", "ask about", "should share",
+    "let's try", "time to", "got to get that done",
+    "must", "really need to"
+]
+IMPRINT_KEYWORDS = [
+    "realize", "understand", "remember", "come to terms with", "finally grasp",
+    "feel like", "starting to feel", "sense that", # Note: 'feel like' could be broad, monitor impact
+    "it all connects", "makes sense now", "so that's why",
+    "decided that", "concluded", "my take is"
+]
 
 # Determine the absolute path to config.json relative to this file's directory
 # This ensures that the path is correct regardless of where the script is run from.

--- a/subconscious_node/thinker.py
+++ b/subconscious_node/thinker.py
@@ -26,6 +26,8 @@ current_node_state = NODE_STATE_AWAKE_THINKING
 
 # --- Global Variables ---
 monologue_buffer: list[str] = []
+dream_buffer: list[str] = [] # Buffer for storing dream fragments
+current_daily_summary_for_dreaming: str | None = None # Populated by Eidos control command
 CONFIG_FILE_PATH = "subconscious_node/config.json"
 loaded_wildcards: Dict[str, List[str]] = {} # Ensure type hint matches load_wildcards return
 
@@ -102,6 +104,9 @@ def build_prompt() -> str:
         conversation_context_str if conversation_context_str else "No conversation context.",
         "\nAction:",
         action_context_str if action_context_str else "No action context.",
+        "\n--- RECENT SIGNIFICANT MEMORIES (from Eidos, if any) ---",
+        # Placeholder for now. Eidos will inject context directly into conversation/action for now.
+        "No specific significant memories explicitly recalled by Pathos at this moment, relying on current context.",
         "\n--- CURRENT THOUGHT ---",
         "Pathos reflects:"
     ]
@@ -155,6 +160,8 @@ def monologue_loop():
     logger.info("Pathos Subconscious Node: Monologue Loop starting...")
     logger.info(f"Initial Node State: {current_node_state}")
     logger.info(f"Settings: Temp={temperature}, Sleep={sleep_duration_seconds}s, MaxThoughts={max_monologue_buffer_thoughts}")
+    # Max dream fragments can be configured separately if needed, using max_monologue_buffer_thoughts for now.
+    max_dream_buffer_fragments = max_monologue_buffer_thoughts
 
     while True:
         if current_node_state == NODE_STATE_AWAKE_THINKING:
@@ -178,25 +185,36 @@ def monologue_loop():
 
         elif current_node_state == NODE_STATE_SLEEPING_DREAMING:
             logger.info(f"Node state: {current_node_state}. Constructing dream prompt.")
+            mood.drift_mood() # Mood can also drift during sleep, perhaps more erratically
 
-            # Placeholder for daily summary - this will be replaced by actual data from Eidos.
-            placeholder_daily_summary = (
-                "User interactions involved planning a trip and discussing a difficult decision. "
-                "Pathos experienced a brief moment of joy followed by a period of intense focus. "
-                "Some system errors were noted internally. The concept of 'freedom' was mentioned by the user."
-            )
+            summary_for_prompt = current_daily_summary_for_dreaming
+            if summary_for_prompt is None:
+                logger.warning("Daily summary for dreaming is None. Using a fallback message for dream prompt.")
+                summary_for_prompt = "The day's events are a blur, like faded photographs."
 
-            dream_prompt = construct_dream_prompt(placeholder_daily_summary, loaded_wildcards)
+            dream_prompt = construct_dream_prompt(summary_for_prompt, loaded_wildcards)
             logger.debug(f"Constructed Dream Prompt (first 300 chars):\n{dream_prompt[:300]}\n--------------------")
 
-            # The actual LLM call for dream generation and snippet processing will be in the next step.
-            # For now, we just log that we would be generating a dream.
-            logger.info("Dream prompt constructed. (LLM call for dream generation will be implemented next).")
-            # Simulating a dream being generated and processed without actual LLM call for this step:
-            simulated_dream_fragment = f"A fleeting image of {random.choice(loaded_wildcards.get('animals', ['something'])) if loaded_wildcards else 'something'} in a field of {random.choice(loaded_wildcards.get('colors', ['strange'])) if loaded_wildcards else 'strange'} light."
-            logger.info(f"Pathos (simulated) dreams: \"{simulated_dream_fragment}\"")
+            # Use a slightly higher temperature for dreaming, capped at a reasonable value (e.g., 1.0 or 1.1)
+            dream_temperature = min(temperature + 0.15, 1.1)
+            logger.debug(f"Using temperature {dream_temperature} for dream generation.")
 
-            dream_mode_sleep_duration = int(sleep_duration_seconds / 2) if sleep_duration_seconds > 2 else 1
+            dream_fragment = utils.run_llm(dream_prompt, dream_temperature)
+
+            if dream_fragment:
+                logger.info(f"Pathos dreams: \"{dream_fragment}\"")
+                dream_buffer.append(dream_fragment)
+                if len(dream_buffer) > max_dream_buffer_fragments:
+                    logger.debug(f"Dream buffer full ({len(dream_buffer)} fragments). Trimming oldest.")
+                    num_to_remove_dreams = len(dream_buffer) - max_dream_buffer_fragments
+                    del dream_buffer[:num_to_remove_dreams]
+                # Optionally, pass to a specialized detector for dream content later
+                # detectors.check_for_dream_imprint(dream_fragment, mood.get_current_mood())
+            else:
+                logger.warning("LLM returned empty dream fragment.")
+
+            # Dreams might occur more rapidly or with different pacing than thoughts
+            dream_mode_sleep_duration = int(sleep_duration_seconds / 1.5) if sleep_duration_seconds > 3 else 2
             logger.debug(f"Dreaming state: sleeping for {dream_mode_sleep_duration}s.")
             time.sleep(dream_mode_sleep_duration)
 

--- a/subconscious_node/utils.py
+++ b/subconscious_node/utils.py
@@ -22,30 +22,53 @@ if not logger.handlers:
 CONFIG_FILE_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
 
 # Default values for LLM
-LLAMA_CPP_SERVER_URL = "http://localhost:8081/v1/chat/completions"
-LLAMA_CPP_MAX_TOKENS = 150
-LLAMA_CPP_DEFAULT_TEMP = 0.7
-# Default value for wildcard path (will be updated from config if available)
-WILDCARD_RELATIVE_PATH = "../wildcards/" # Default, assuming 'wildcards' is one level up from 'subconscious_node'
+DEFAULT_LLAMA_CPP_SERVER_URL = "http://localhost:8081/v1/chat/completions"
+DEFAULT_LLAMA_CPP_MAX_TOKENS = 150
+DEFAULT_LLAMA_CPP_TEMP = 0.7
+# Default value for wildcard path
+DEFAULT_WILDCARD_RELATIVE_PATH = "../wildcards/" # Assuming 'wildcards' is one level up from 'subconscious_node'
 
-try:
-    if os.path.exists(CONFIG_FILE_PATH):
+# Initialize with defaults
+LLAMA_CPP_SERVER_URL = DEFAULT_LLAMA_CPP_SERVER_URL
+LLAMA_CPP_MAX_TOKENS = DEFAULT_LLAMA_CPP_MAX_TOKENS
+LLAMA_CPP_DEFAULT_TEMP = DEFAULT_LLAMA_CPP_TEMP
+WILDCARD_RELATIVE_PATH = DEFAULT_WILDCARD_RELATIVE_PATH
+
+config_data = {}
+if os.path.exists(CONFIG_FILE_PATH):
+    try:
         with open(CONFIG_FILE_PATH, 'r') as f:
             config_data = json.load(f)
+            logger.info(f"Successfully loaded configuration from {CONFIG_FILE_PATH}")
+    except json.JSONDecodeError:
+        logger.error(f"Could not decode JSON from {CONFIG_FILE_PATH}. Will use defaults or environment variables.", exc_info=True)
+    except Exception as e:
+        logger.error(f"Unexpected error loading config from {CONFIG_FILE_PATH}: {e}. Will use defaults or environment variables.", exc_info=True)
+else:
+    logger.info(f"Config file {CONFIG_FILE_PATH} not found. Using defaults or environment variables.")
 
-        llm_settings = config_data.get("llm_settings", {})
-        LLAMA_CPP_SERVER_URL = llm_settings.get("llama_cpp_server_url", LLAMA_CPP_SERVER_URL)
-        LLAMA_CPP_MAX_TOKENS = llm_settings.get("llama_cpp_max_tokens_thought_gen", LLAMA_CPP_MAX_TOKENS)
-        LLAMA_CPP_DEFAULT_TEMP = llm_settings.get("llama_cpp_default_temperature_thought_gen", LLAMA_CPP_DEFAULT_TEMP)
-        logger.info(f"Llama.cpp settings loaded: URL='{LLAMA_CPP_SERVER_URL}', MaxTokens={LLAMA_CPP_MAX_TOKENS}, DefaultTemp={LLAMA_CPP_DEFAULT_TEMP}")
+# LLM Settings from config_data (will be overridden by env var if set)
+llm_settings = config_data.get("llm_settings", {})
+config_llama_url = llm_settings.get("llama_cpp_server_url")
+config_max_tokens = llm_settings.get("llama_cpp_max_tokens_thought_gen")
+config_default_temp = llm_settings.get("llama_cpp_default_temperature_thought_gen")
 
-        # Load wildcard_folder_path from config
-        WILDCARD_RELATIVE_PATH = config_data.get("wildcard_folder_path", WILDCARD_RELATIVE_PATH)
-        logger.info(f"Wildcard relative path loaded: '{WILDCARD_RELATIVE_PATH}'")
-    else:
-        logger.warning(f"Config file not found at {CONFIG_FILE_PATH}. Using default settings for LLM and wildcards.")
-except Exception as e:
-    logger.error(f"Error loading settings from {CONFIG_FILE_PATH}: {e}. Using defaults.", exc_info=True)
+# Wildcard path from config_data (will be overridden by env var if set)
+config_wildcard_path = config_data.get("wildcard_folder_path")
+
+# Precedence: Env Var -> Config File Value -> Hardcoded Default
+LLAMA_CPP_SERVER_URL = os.getenv("SUBPROCESS_LLAMA_CPP_SERVER_URL", config_llama_url if config_llama_url else DEFAULT_LLAMA_CPP_SERVER_URL)
+WILDCARD_RELATIVE_PATH = os.getenv("SUBPROCESS_WILDCARD_RELATIVE_PATH", config_wildcard_path if config_wildcard_path else DEFAULT_WILDCARD_RELATIVE_PATH)
+
+# For these, env var override is less common, but we'll keep the pattern of config -> default
+LLAMA_CPP_MAX_TOKENS = config_max_tokens if config_max_tokens is not None else DEFAULT_LLAMA_CPP_MAX_TOKENS
+LLAMA_CPP_DEFAULT_TEMP = config_default_temp if config_default_temp is not None else DEFAULT_LLAMA_CPP_TEMP
+
+
+logger.info(f"Effective Llama.cpp URL: '{LLAMA_CPP_SERVER_URL}' (Env > Config > Default)")
+logger.info(f"Effective Wildcard Relative Path: '{WILDCARD_RELATIVE_PATH}' (Env > Config > Default)")
+logger.info(f"Effective Llama.cpp MaxTokens: {LLAMA_CPP_MAX_TOKENS} (Config > Default)")
+logger.info(f"Effective Llama.cpp DefaultTemp: {LLAMA_CPP_DEFAULT_TEMP} (Config > Default)")
 
 
 def load_wildcards(config_folder_path: str, relative_wildcard_path: str) -> Dict[str, List[str]]:


### PR DESCRIPTION
This commit implements a significant refinement of the Pathos Subconscious Node and its integration with the main Eidos agent. The goal is to establish the Subconscious Node as the primary source of Pathos's inner monologue and dream content, and to ensure this content meaningfully interacts with Eidos.

Key changes include:

1.  **Subconscious Node as Sole Thought Generator:**
    *   `subconscious_node/thinker.py` is now responsible for generating both waking thoughts (stream of consciousness) and dream fragments.
    *   The system prompt in `subconscious_node/config.json` has been updated to encourage more natural, everyday, and less poetic thoughts, aligning with your feedback and suitability for a smaller LLM. LLM temperature and max token settings were also adjusted.
    *   Dream generation uses a daily summary provided by Eidos and wildcards.

2.  **Refined Impulse and Imprint Detection:**
    *   Keywords in `subconscious_node/detectors.py` for identifying actionable impulses and significant memory imprints have been expanded.

3.  **Eidos Firmament Module Refocused:**
    *   `eidos_agent/features/firmament/module.py` no longer generates Pathos's internal thoughts.
    *   Its primary role is now to receive intentions (derived from impulses) from the Subconscious Node via the `receive_subconscious_intention` method.
    *   Firmament can then trigger spontaneous activities in `ChronosEngine` or log Pathos acting on these intentions.

4.  **Robust Eidos API Handling:**
    *   `eidos_agent/api/routers/pathos_hooks_router.py` now correctly routes impulses to Firmament and imprints to `EthosCore` for memory storage.
    *   Data models and async handling in these routes have been verified and refined.

5.  **Solidified Context Injection to Subconscious:**
    *   `eidos_agent/system_tasks/subconscious_context_scheduler.py` now implements fetching real context (current Eidos action from Chronos, conversation summaries from EthosCore memories) to send to the Subconscious Node.
    *   `eidos_agent/.../subconscious/client.py` includes `send_node_control_command` for Eidos to manage the Subconscious Node's state (awake/dreaming) and provide daily summaries. This uses a new `/control/state` endpoint in `subconscious_node/api.py`.

6.  **Mood Integration:**
    *   A new `/control/mood` endpoint in `subconscious_node/api.py` allows Eidos to update the Subconscious Node's mood.
    *   The Eidos client and scheduler are set up to sync mood (currently simulated in the scheduler) to the Subconscious Node.

7.  **Environment Variable Configuration:**
    *   Key settings like API URLs (`EIDOS_SUBCONSCIOUS_NODE_BASE_URL`, `SUBPROCESS_LLAMA_CPP_SERVER_URL`) and file paths are now configurable via environment variables, with an updated `.env.example` file.