### PR TITLE
Fix: Resolve MemoryEntry ImportError and apply syntax fixes.

### DIFF
--- a/experimental/eidos/eidos_agent/services/memory_ingestion_service.py
+++ b/experimental/eidos/eidos_agent/services/memory_ingestion_service.py
@@ -2,7 +2,7 @@ from typing import Optional, List, Dict, Any, Union
 import uuid
 from datetime import datetime, timezone
 
-from eidos_agent.persona_logic.ethos_core.memory_storage import MemoryEntry
+from eidos_agent.persona_logic.ethos_core import MemoryEntry
 from eidos_agent.utils.logger import get_logger # Corrected logger import
 
 logger = get_logger(__name__)


### PR DESCRIPTION
- I modified the import for MemoryEntry in memory_ingestion_service.py to import from the package level (eidos_agent.persona_logic.ethos_core) instead of directly from memory_storage.py. This aims to prevent potential import cycle issues.
- I applied syntax and indentation corrections to:
  - experimental/eidos/eidos_agent/persona_logic/ethos_core/core.py
  - experimental/eidos/eidos_agent/persona_logic/ethos_core/memory_storage.py These fixes were identified and applied during testing.

Note: Full testing of the application startup was prevented by an out-of-disk-space error, which blocked the installation of the 'sentence-transformers' dependency.