### PR TITLE
Fix IndentationError in ethos_core.py

### DIFF
--- a/experimental/eidos/eidos_agent/persona_logic/ethos_core/core.py
+++ b/experimental/eidos/eidos_agent/persona_logic/ethos_core/core.py
@@ -760,7 +760,6 @@ class EthosCore:
         
         return datetime.now(timezone.utc)
     
-no
     async def process_interaction_for_hexus_update(self, user_input_text: str, pathos_response_text: Optional[str], image_provided: bool, document_provided: bool):
         """
         Determines Pathos's subjective reaction to a user interaction and updates Hexus scores.


### PR DESCRIPTION
Removes an extraneous "no" line that was causing an IndentationError in `experimental/eidos/eidos_agent/persona_logic/ethos_core/core.py`. This prevented the `process_interaction_for_hexus_update` function from being correctly parsed.