### PR TITLE
Fix: Resolve ModuleNotFoundError for eidos_agent.schemas

### DIFF
--- a/eidos/eidos_agent/schemas/__init__.py
+++ b/eidos/eidos_agent/schemas/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'schemas' directory a Python package.


### PR DESCRIPTION
Added an `__init__.py` file to the `eidos/eidos_agent/schemas/` directory. This allows the directory to be recognized as a Python package, resolving the `ModuleNotFoundError: No module named 'eidos_agent.schemas'` that occurred when trying to import schema modules like `ethos_schemas` from it.