### PR TITLE
Fix: Correct IndentationError in pathos_interface.py

### DIFF
--- a/eidos/eidos_agent/llm_integrations/pathos_interface.py
+++ b/eidos/eidos_agent/llm_integrations/pathos_interface.py
@@ -842,8 +842,11 @@ class PathosInterface:
         logger.debug(f"TTS_SEND ({user_id}, {sequence_num}, {log_prefix}): START for sentence: '{sentence[:30]}...'")
 
         audio_bytes: Optional[bytes] = None
-        try: audio_bytes = await self.eidos_tts_service_instance.synthesize(text=sentence)
-        except Exception as e_synth: logger.error(f"TTS_SEND ({user_id}, {sequence_num}): Exception during synthesize: {e_synth}", exc_info=True); return
+        try:
+            audio_bytes = await self.eidos_tts_service_instance.synthesize(text=sentence)
+        except Exception as e_synth:
+            logger.error(f"TTS_SEND ({user_id}, {sequence_num}): Exception during synthesize: {e_synth}", exc_info=True)
+            return
 
         if audio_bytes:
             logger.info(f"TTS_SEND ({user_id}, {sequence_num}): Audio bytes received. Caching with chunk_id: {final_chunk_id}.")


### PR DESCRIPTION
Re-indented a try-except block and an if-else block within the `send_sentence_to_tts_and_notify_client` method in `eidos/eidos_agent/llm_integrations/pathos_interface.py`. This change addresses an `IndentationError: unindent does not match any outer indentation level` that was preventing the application from starting.